### PR TITLE
Allow diego manifest generation script to vary by INFRASTRUCTURE

### DIFF
--- a/pipelines/cf-release.yml
+++ b/pipelines/cf-release.yml
@@ -1044,6 +1044,7 @@ jobs:
         DEPLOYMENTS_DIR: deployments-runtime
         BOSH_USER: {{a1_bosh_username}}
         BOSH_PASSWORD: {{a1_bosh_password}}
+        INFRASTRUCTURE: aws
   - put: cf-a1-diego-manifest
     params:
       file: generated-diego-manifest/diego-deployment.yml
@@ -1710,6 +1711,7 @@ jobs:
         DEPLOYMENTS_DIR: deployments-runtime
         BOSH_USER: {{a1_bosh_username}}
         BOSH_PASSWORD: {{a1_bosh_password}}
+        INFRASTRUCTURE: aws
   - task: emit-diego-datadog-started
     file: runtime-ci/scripts/ci/emit-datadog-event/task.yml
     config:

--- a/scripts/ci/generate-diego-manifest/task
+++ b/scripts/ci/generate-diego-manifest/task
@@ -16,6 +16,7 @@ ENVIRONMENT_NAME="${ENVIRONMENT_NAME:?"\$ENVIRONMENT_NAME not set"}"
 BOSH_USER="${BOSH_USER:?"\$BOSH_USER not set"}"
 BOSH_PASSWORD="${BOSH_PASSWORD:?"\$BOSH_PASSWORD not set"}"
 BOSH_TARGET="${BOSH_TARGET:?"\$BOSH_TARGET not set"}"
+INFRASTRUCTURE="${INFRASTRUCTURE:?"\$INFRASTRUCTURE not set"}"
 
 # Outputs
 GENERATED_DIEGO_MANIFEST_DIR="${root_dir}/${GENERATED_DIEGO_MANIFEST_DIR:?"\$GENERATED_DIEGO_MANIFEST_DIR not set"}"
@@ -34,7 +35,7 @@ scripts_dir="$(cd "${my_dir}/.." && pwd)"
 pushd "${DIEGO_RELEASE_DIR}"
   bosh download manifest "${cf_deployment_name}" > /tmp/cf.yml
   spiff merge \
-    manifest-generation/misc-templates/aws-iaas-settings.yml \
+    "manifest-generation/misc-templates/${INFRASTRUCTURE}-iaas-settings.yml" \
     "${templates_path}/diego/iaas-settings-internal.yml" \
     "${stubs_path}/diego/iaas-settings.yml" \
     /tmp/cf.yml \

--- a/scripts/ci/generate-diego-manifest/task.yml
+++ b/scripts/ci/generate-diego-manifest/task.yml
@@ -19,6 +19,7 @@ params:
   DEPLOYMENTS_RUNTIME_DIR: deployments-runtime
   DIEGO_RELEASE_DIR: diego-release
   GENERATED_DIEGO_MANIFEST_DIR: generated-diego-manifest
+  INFRASTRUCTURE: ~
 
 run:
   path: runtime-ci/scripts/ci/generate-diego-manifest/task


### PR DESCRIPTION
Note: [diego-release](https://github.com/cloudfoundry-incubator/diego-release) does not yet support any IaaS other than `aws`. See: https://github.com/cloudfoundry-incubator/diego-release/tree/develop/manifest-generation/misc-templates/