### PR TITLE
CATS docker image uses latest container networking CLI plugin

### DIFF
--- a/scripts/ci/run-cats/Dockerfile
+++ b/scripts/ci/run-cats/Dockerfile
@@ -29,7 +29,7 @@ RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&source
   dpkg -i cf.deb
 
 # Install the container networking CLI plugin
-RUN wget -q -O /tmp/network-policy-plugin "https://github.com/cloudfoundry-incubator/netman-release/releases/download/v0.5.0/network-policy-plugin-linux64" && \
+RUN wget -q -O /tmp/network-policy-plugin "https://github.com/cloudfoundry-incubator/netman-release/releases/download/v0.11.0/network-policy-plugin-linux64" && \
   chmod +x /tmp/network-policy-plugin && \
   cf install-plugin /tmp/network-policy-plugin -f && \
   rm -rf /tmp/*


### PR DESCRIPTION
new plugin adds compatibility with GCP's HTTP load balancer