### PR TITLE
Update loggregator-release URL

### DIFF
--- a/pipelines/update-releases.yml
+++ b/pipelines/update-releases.yml
@@ -163,7 +163,7 @@ resources:
 - name: loggregator-release
   type: bosh-io-release
   source:
-    repository: cloudfoundry/loggregator
+    repository: cloudfoundry/loggregator-release
 - name: nats-release
   type: bosh-io-release
   source:


### PR DESCRIPTION
bosh.io has not been updated yet. Once the bosh.io release name has changed for loggregator this will need to be merged.