### PR TITLE
update-manifest-releases should ignore .github dir

### DIFF
--- a/util/update-manifest-releases/main.go
+++ b/util/update-manifest-releases/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cloudfoundry/runtime-ci/util/update-manifest-releases/opsfile"
 )
 
-var cfDeploymentIgnoreDirs = []string{".git", "scripts", "example-vars-files", "iaas-support", "ci", "units"}
+var cfDeploymentIgnoreDirs = []string{".git", ".github", "scripts", "example-vars-files", "iaas-support", "ci", "units"}
 var cfDeploymentIgnoreFiles = []string{
 	"cf-deployment.yml",
 	".overcommit.yml",


### PR DESCRIPTION
Add .github to the list of ignored directories in cf-d.

Recently added a .github folder to the cf-deployment repo, and it contains yaml files that were pulled in by this util. This util would then fail because the yaml files in that folder are not ops files, and therefore are not in the format that this util expected them to be in.