### PR TITLE
Update: use golang:1.19.5-bullseye as a base for relint-base

### DIFF
--- a/dockerfiles/relint-base/Dockerfile
+++ b/dockerfiles/relint-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.5-buster
+FROM golang:1.19.5-bullseye
 
 ENV jq_version 1.6
 ENV jq_checksum 056ba5d6bbc617c29d37158ce11fd5a443093949


### PR DESCRIPTION
Bullseye is the latest stable Debian version, Buster is the oldstable version.

Resolves #126 