### PR TITLE
Use "cloudfoundry/bbl-deployment" for gcloud task

### DIFF
--- a/tasks/manage-gcp-dns/task.yml
+++ b/tasks/manage-gcp-dns/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cloudfoundry/cf-deployment-concourse-tasks
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
   - name: runtime-ci


### PR DESCRIPTION
Old image https://hub.docker.com/r/cfinfrastructure/deployment has been migrated to https://hub.docker.com/repository/docker/cloudfoundry/bbl-deployment