### PR TITLE
CI: don't delete cf deployment in lite before destroying the director

### DIFF
--- a/ci/infrastructure.yml
+++ b/ci/infrastructure.yml
@@ -947,14 +947,6 @@ jobs:
       params: {claim: snitch}
     - get: relint-envs
     - get: cf-deployment-concourse-tasks
-  - try:
-      do:
-      - task: guarantee-no-existing-cf-deployment
-        file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
-        input_mapping:
-          bbl-state: relint-envs
-        params:
-          BBL_STATE_DIR: environments/test/snitch/bbl-state
   - task: destroy-infrastructure
     file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
     input_mapping:


### PR DESCRIPTION
Since lite is a bosh-lite, which reuses the director VM for the any bosh deployments, we don't need to delete deployments before destroying the director.

We usually only run the destroy-infrastructure-lite job when snitch is in a bad state, and I've had to remove this step several times recently to run the job.