### PR TITLE
chore(dependabot): Increase interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,34 +3,34 @@ updates:
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 
 - package-ecosystem: "gomod"
   directory: "/ci/resources/stemcell-version-bump"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 
 - package-ecosystem: "gomod"
   directory: "/tasks/lookup-slack-channel-for-release-owner"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 
 - package-ecosystem: "gomod"
   directory: "/util/cat-search-tool"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 
 - package-ecosystem: "gomod"
   directory: "/util/update-manifest-releases"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 
 - package-ecosystem: "docker"
   directory: "/dockerfiles/bosh-cli"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 
 - package-ecosystem: "docker"
   directory: "/dockerfiles/relint-base"
   schedule:
-    interval: "daily"
+    interval: "weekly"


### PR DESCRIPTION
Updates dependabot configurationt to scan for dependency bumps weekly rather than daily.

Daily can sometimes lead to PR overload. Additionally, any security bumps will be created outside of this schedule anyway.