### PR TITLE
Use registry-image instead of docker-image concourse resource

### DIFF
--- a/tasks/ensure-api-healthy/task.yml
+++ b/tasks/ensure-api-healthy/task.yml
@@ -2,9 +2,10 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
+    tag: latest
 
 inputs:
 - name: runtime-ci


### PR DESCRIPTION
newer and because the docker-image one failed to pull image in ARI concourse

+ @sethboyles @ctlong 