### PR TITLE
Disable skip_ssl_validation for deploy-smokes task

### DIFF
--- a/tasks/bosh-deploy-smokes/task
+++ b/tasks/bosh-deploy-smokes/task
@@ -52,7 +52,7 @@ instance_groups:
         org: cf_smoke_tests_org
         space: cf_smoke_tests_space
         cf_dial_timeout_in_seconds: 300
-        skip_ssl_validation: true
+        skip_ssl_validation: false
 
 - name: smoke-tests-windows
   lifecycle: errand
@@ -80,7 +80,7 @@ instance_groups:
         org: cf_smoke_tests_org
         space: cf_smoke_tests_space
         cf_dial_timeout_in_seconds: 300
-        skip_ssl_validation: true
+        skip_ssl_validation: false
         windows_stack: windows
 
 stemcells:


### PR DESCRIPTION
* test environment uses a certificate that is signed with the relint_ca