### PR TITLE
fix(ci/infrastructure): Use correct smoke-tests account key path

### DIFF
--- a/ci/infrastructure.yml
+++ b/ci/infrastructure.yml
@@ -1190,7 +1190,7 @@ jobs:
       input_mapping:
         bbl-state: relint-envs
       params:
-        BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/smoke-tests/ard-smoke-tests.key.json
+        BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/smoke-tests/smoke-tests.key.json
         BBL_STATE_DIR: environments/test/smoke-tests/bbl-state
         GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
         GIT_COMMIT_USERNAME: "ARD WG Bot"


### PR DESCRIPTION
Fixes the smoke-tests account key path in the `destroy-infrastructure-smoke-tests` job.