### PR TITLE
fix(tasks/run-cf-test-helpers-unit-tests): Run tests with go run

### DIFF
--- a/tasks/run-cf-test-helpers-unit-tests/task
+++ b/tasks/run-cf-test-helpers-unit-tests/task
@@ -1,6 +1,5 @@
 #!/bin/bash -exu
 
 pushd cf-test-helpers
-  go install github.com/onsi/ginkgo/v2/ginkgo
-  ginkgo -r --procs=3 --compilers=3 --randomize-all --randomize-suites --fail-on-pending --keep-going --race --trace
+  go run github.com/onsi/ginkgo/v2/ginkgo -r --procs=3 --compilers=3 --randomize-all --randomize-suites --fail-on-pending --keep-going --race --trace
 popd


### PR DESCRIPTION
Runs ginkgo tests in `tasks/run-cf-test-helpers-unit-tests` with `go run github.com/onsi/ginkgo/v2/ginkgo ...` instead of `go install github.com/onsi/ginkgo/v2/ginkgo; gingko ...`.