### PR TITLE
Replace /v2/info with /v3/info and enable https

### DIFF
--- a/tasks/ensure-api-healthy/task
+++ b/tasks/ensure-api-healthy/task
@@ -34,7 +34,7 @@ EOT
     cf push healthy-app -f cf-smoke-tests/assets/binary/manifest.yml -p cf-smoke-tests/assets/binary -b binary_buildpack
     TARGET_URL="https://healthy-app.$(jq -r .isolation_segment_domain "${CONFIG_FILE}")"
   else
-    TARGET_URL="http://$(jq -r .api "${CONFIG_FILE}")/v2/info"
+    TARGET_URL="https://$(jq -r .api "${CONFIG_FILE}")/v3/info"
   fi
 
   go run runtime-ci/tasks/ensure-api-healthy/main.go "${TARGET_URL}"


### PR DESCRIPTION
* we have a first test env where /v2/info is completely disabled -> use /v3/info
* also enable TLS (http client has InsecureSkipVerify: true set, so this should also work with self-signed load balancer certificates)