### PR TITLE
Exclude noble stemcell from release notes for now

### DIFF
--- a/tasks/cf-deployment-release-notes-template/ops_file_finder.rb
+++ b/tasks/cf-deployment-release-notes-template/ops_file_finder.rb
@@ -5,7 +5,7 @@ class OpsFileFinder
     )
 
     opsfile_list = ops_files_and_directories.select do |fd|
-      File.file?(fd) unless fd.match(/(use-compiled-releases.yml|test\/fips-stemcell.yml)/)
+      File.file?(fd) unless fd.match(/(use-compiled-releases.yml|test\/fips-stemcell.yml|experimental\/use-noble-stemcell.yml)/)
     end
 
     opsfile_list.map { |opsfile| opsfile.gsub!("#{repo_dir}/operations/", '') }


### PR DESCRIPTION
* the version will show up as "latest" in the release notes which is not helpful