### PR TITLE
CFDEPLOY-191:Bump golang from 1.23.8-bullseye to 1.24-bookworm in /do…

### DIFF
--- a/dockerfiles/relint-base/Dockerfile
+++ b/dockerfiles/relint-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.8-bullseye
+FROM golang:1.24-bookworm
 
 RUN set -eux; \
       apt-get update; \


### PR DESCRIPTION
…ckerfiles/relint-base