### PR TITLE
Add new load balancer type nlb for IPv6 validation

### DIFF
--- a/ci/infrastructure.yml
+++ b/ci/infrastructure.yml
@@ -347,6 +347,7 @@ ipv6-bbl-up-task: &ipv6-bbl-up-task-config
     BBL_LB_CERT: ((dobby_lb.certificate))
     BBL_LB_CERT_CHAIN: ((dobby_lb.ca))
     BBL_LB_KEY: ((dobby_lb.private_key))
+    BBL_LB_TYPE: nlb
     BBL_STATE_DIR: environments/test/dobby/bbl-state
     GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
     GIT_COMMIT_USERNAME: "ARD WG Bot"


### PR DESCRIPTION
This adjustment to the pipeline is required as a result of this PR:

https://github.com/cloudfoundry/bosh-bootloader/pull/644

After the new load balancer type has been introduced, we need to apply it in our IPv6 validation pipeline. 

