### PR TITLE
Support Noble stemcell URLs in detect-stemcell-bump task

### DIFF
--- a/tasks/detect-stemcell-bump/concourseio/runner.go
+++ b/tasks/detect-stemcell-bump/concourseio/runner.go
@@ -149,7 +149,7 @@ func buildSubDir(buildDir, subDir string) (string, error) {
 }
 
 func parseOSfromURL(url string) (string, error) {
-	versionRegex := regexp.MustCompile(`(ubuntu-.*)-go_agent.tgz`)
+	versionRegex := regexp.MustCompile(`(ubuntu-[a-z]+(?:-[a-z]+)*?)(?:-go_agent)?\.tgz`)
 
 	allMatches := versionRegex.FindAllStringSubmatch(url, 1)
 


### PR DESCRIPTION
Noble stemcells dropped the "-go_agent" suffix from their URLs. Update the regex to make it optional so both jammy and noble URLs are handled.