### PR TITLE
Update smoke-tests manifest stemcell to ubuntu-noble

### DIFF
--- a/tasks/bosh-deploy-smokes/task
+++ b/tasks/bosh-deploy-smokes/task
@@ -20,7 +20,7 @@ addons:
 - name: bpm
   include:
     stemcell:
-    - os: ubuntu-jammy
+    - os: ubuntu-noble
   jobs:
   - name: bpm
     release: bpm
@@ -85,7 +85,7 @@ instance_groups:
 
 stemcells:
 - alias: default
-  os: ubuntu-jammy
+  os: ubuntu-noble
   version: latest
 - alias: windows2019
   os: windows2019


### PR DESCRIPTION
## Summary
- Update `bosh-deploy-smokes` task to use `ubuntu-noble` stemcell instead of `ubuntu-jammy`
- The cf-smoke-tests environment now runs Noble stemcell (cf-deployment v56.0.0 defaults to Noble)