### PR TITLE
New task "bosh-extend-runtime-config" for fixing BOSH Lite config

### DIFF
--- a/ci/infrastructure.yml
+++ b/ci/infrastructure.yml
@@ -982,6 +982,16 @@ jobs:
         SECOND_DIR: environments/test/snitch/bbl-config
     - task: update-infrastructure
       <<: *lite-bbl-up-task-config
+    - task: bosh-extend-runtime-config
+      file: runtime-ci/tasks/bosh-extend-runtime-config/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        ops-file: relint-envs
+      params:
+        BBL_STATE_DIR: environments/test/snitch/bbl-state
+        OPS_FILE_PATH: environments/test/snitch/bbl-config/warden-noble-dns.yml
+        RUNTIME_CONFIG_NAME: dns
+
     - put: lite-pool
       params: {release: lite-pool}
 

--- a/tasks/bosh-extend-runtime-config/task
+++ b/tasks/bosh-extend-runtime-config/task
@@ -1,0 +1,15 @@
+#!/bin/bash -exu
+
+set -o pipefail
+
+# Not able to resolve our import via shellcheck, so disable warning
+# shellcheck disable=SC1091
+source cf-deployment-concourse-tasks/shared-functions
+
+function main() {
+  setup_bosh_env_vars
+
+  bosh update-runtime-config -n --name ${RUNTIME_CONFIG_NAME} <(bosh int <(bosh runtime-config --name ${RUNTIME_CONFIG_NAME}) -o ops-file/${OPS_FILE_PATH})
+}
+
+main

--- a/tasks/bosh-extend-runtime-config/task.yml
+++ b/tasks/bosh-extend-runtime-config/task.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cloudfoundry/bosh-cli
+
+inputs:
+- name: runtime-ci
+- name: bbl-state
+- name: ops-file
+- name: cf-deployment-concourse-tasks
+
+run:
+  path: runtime-ci/tasks/bosh-extend-runtime-config/task
+
+params:
+  BBL_STATE_DIR: bbl-state
+  OPS_FILE_PATH:
+  RUNTIME_CONFIG_NAME:


### PR DESCRIPTION
* new task can patch a BOSH runtime config, similar to bosh-extend-cloud-config
* note that the config name must be explicitly specified (e.g. "dns")
* use task in BOSH Lite setup to patch DNS config for Noble/Warden stemcell