### PR TITLE
chore: Remove Old CF CLI binary from bosh-cli docker image

### DIFF
--- a/dockerfiles/bosh-cli/Dockerfile
+++ b/dockerfiles/bosh-cli/Dockerfile
@@ -38,9 +38,3 @@ RUN \
   cd /usr/local/bin && \
   chmod +x terraform && \
   rm -rf /tmp/*
-
-RUN \
-  wget -q -O cf.deb \
-  "https://cli.run.pivotal.io/stable?release=debian64&version=6.28.0&source=github-rel"
-
-RUN dpkg -i cf.deb


### PR DESCRIPTION
Removed Cloud Foundry CLI v6.28.0.
Cleaned up the unused cf.deb package download.
Reduces final image size and eliminates deprecated, insecure binaries. The build bosh-cli job is failing and this PR aim to fixes:https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/build-docker-images/jobs/build-bosh-cli-docker-image/builds/590